### PR TITLE
Fix vulnerabilities in npm audit

### DIFF
--- a/codewords_core/package.json
+++ b/codewords_core/package.json
@@ -16,7 +16,7 @@
   "author": "Google, inc.; Andrew n marshall",
   "license": "UNLICENSED",
   "devDependencies": {
-    "gts": "^0.5.1",
+    "gts": "^0.9.0",
     "jasmine-core": "^2.8.0",
     "karma": "^4.1.0",
     "karma-chrome-launcher": "^2.2.0",

--- a/codewords_core/package.json
+++ b/codewords_core/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "gts": "^0.5.1",
     "jasmine-core": "^2.8.0",
-    "karma": "^1.7.1",
+    "karma": "^4.1.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-jasmine": "^1.1.0",
     "tslint": "^5.8.0",

--- a/codewords_lang_js/package.json
+++ b/codewords_lang_js/package.json
@@ -16,7 +16,7 @@
   "author": "Google, inc.; Andrew n marshall",
   "license": "UNLICENSED",
   "devDependencies": {
-    "gts": "^0.5.1",
+    "gts": "^0.9.0",
     "jasmine-core": "^2.8.0",
     "karma": "^4.1.0",
     "karma-chrome-launcher": "^2.2.0",

--- a/codewords_lang_js/package.json
+++ b/codewords_lang_js/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "gts": "^0.5.1",
     "jasmine-core": "^2.8.0",
-    "karma": "^1.7.1",
+    "karma": "^4.1.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-jasmine": "^1.1.0",
     "tslint": "^5.8.0",


### PR DESCRIPTION
Updating Karma to 4.1.0, and gts to 0.9.0. This resolves all former vulnerabilities.

`npm test` continues to pass in `codewords_core`, and fails as before in `codewords_lang_js`.